### PR TITLE
Fix: naming and exception messages cleanup

### DIFF
--- a/trunk/Source/Launcher/Launcher.cpp
+++ b/trunk/Source/Launcher/Launcher.cpp
@@ -77,7 +77,7 @@ void handle_height(CommandLine::Parameters& cmds){
     int height = static_cast<int>(StringTools::parse_sL_text(value));
     Console::set_console_window_size(80, height);
 }
-void handles_skip_warnings(CommandLine::Parameters& cmds){
+void handle_skip_warnings(CommandLine::Parameters& cmds){
     cmds.advance();
     pause_on_warning = false;
 }
@@ -86,7 +86,7 @@ CommandLine::ActionMap GLOBAL_COMMANDS{
     {"console", handle_console},
     {"colors", handle_colors},
     {"height", handle_height},
-    {"skip-warnings", handles_skip_warnings},
+    {"skip-warnings", handle_skip_warnings},
 };
 void process_startup_commands(CommandLine::Parameters& cmds){
     while (cmds.has_more() && cmds.match_execute(GLOBAL_COMMANDS, false));

--- a/trunk/Source/PublicLibs/BasicLibs/StringTools/ConvertInteger.h
+++ b/trunk/Source/PublicLibs/BasicLibs/StringTools/ConvertInteger.h
@@ -61,7 +61,9 @@ std::string tostr_ui_commas(const IntegerType& x, char separator = ','){
 template <typename IntegerType>
 std::string tostr_si_commas(const IntegerType& x, char separator = ','){
     if (x < 0){
-        return std::string("-") + tostr_ui_commas<IntegerType>(-x, separator);
+        std::string out = "-";
+        out += tostr_ui_commas<IntegerType>(-x, separator);
+        return out;
     }else{
         return tostr_ui_commas<IntegerType>(x, separator);
     }

--- a/trunk/Source/PublicLibs/SystemLibs/FileIO/BaseFile/BaseFile_Default.ipp
+++ b/trunk/Source/PublicLibs/SystemLibs/FileIO/BaseFile/BaseFile_Default.ipp
@@ -67,6 +67,8 @@ void BaseFile::rename(std::string path){
         throw FileException("BaseFile::rename()", std::move(path), "File isn't open.");
     }
 
+    //  Exception messages use BaseFile::rename() as the function name
+    //  since this code is part of BaseFile, not RawFile.
     std::string old_path = m_path;
     close();
 
@@ -76,7 +78,7 @@ void BaseFile::rename(std::string path){
         if (errno != EEXIST){
             int errorcode = errno;
             throw FileException(
-                errorcode, "RawFile::rename()",
+                errorcode, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file."
             );
@@ -86,7 +88,7 @@ void BaseFile::rename(std::string path){
         if (remove(path.c_str())){
             int errorcode = errno;
             throw FileException(
-                errorcode, "RawFile::rename()",
+                errorcode, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file because the existing one can't be deleted."
             );
@@ -96,7 +98,7 @@ void BaseFile::rename(std::string path){
         if (::rename(old_path.c_str(), path.c_str())){
             int errorcode = errno;
             throw FileException(
-                errorcode, "RawFile::rename()",
+                errorcode, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file."
             );
@@ -105,7 +107,7 @@ void BaseFile::rename(std::string path){
 
     if (!open(std::move(path))){
         throw FileException(
-            "RawFile::rename()",
+            "BaseFile::rename()",
             std::move(path),
             "Unable to reopen file."
         );

--- a/trunk/Source/PublicLibs/SystemLibs/FileIO/BaseFile/BaseFile_Windows.ipp
+++ b/trunk/Source/PublicLibs/SystemLibs/FileIO/BaseFile/BaseFile_Windows.ipp
@@ -89,6 +89,8 @@ void BaseFile::rename(std::string path){
         throw FileException("BaseFile::rename()", std::move(path), "File isn't open.");
     }
 
+    //  Exception messages use BaseFile::rename() as the function name
+    //  since this code is part of BaseFile, not RawFile.
     std::string old_path = m_path;
     std::wstring old_wpath = StringTools::utf8_to_wstr(old_path);
     std::wstring new_wpath = StringTools::utf8_to_wstr(path);
@@ -104,7 +106,7 @@ void BaseFile::rename(std::string path){
         //  Failed because of something other than file already exists.
         if (err != EEXIST){
             throw FileException(
-                err, "RawFile::rename()",
+                err, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file."
             );
@@ -113,7 +115,7 @@ void BaseFile::rename(std::string path){
         //  File already exists. Remove the existing one.
         if (_wremove(new_wpath.c_str())){
             throw FileException(
-                err, "RawFile::rename()",
+                err, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file because the existing one can't be deleted."
             );
@@ -124,7 +126,7 @@ void BaseFile::rename(std::string path){
             //  Failed again
             _get_errno(&err);
             throw FileException(
-                err, "RawFile::rename()",
+                err, "BaseFile::rename()",
                 std::move(old_path),
                 "Unable to rename file."
             );
@@ -133,7 +135,7 @@ void BaseFile::rename(std::string path){
 
     if (!open(path)){
         throw FileException(
-            "RawFile::rename()",
+            "BaseFile::rename()",
             std::move(path),
             "Unable to reopen file."
         );


### PR DESCRIPTION
## Summary
Code quality and consistency improvements: naming fixes and correct function names in exception messages.

## Changes
- **Launcher:** Rename `handles_skip_warnings` → `handle_skip_warnings` to match other command handlers (`handle_pause`, `handle_colors`, etc.).
- **BaseFile (Default & Windows):** Use `"BaseFile::rename()"` in `FileException` messages inside `BaseFile::rename()` instead of `"RawFile::rename()"`; add short comment explaining the choice.
- **ConvertInteger.h:** Build negative result in `tostr_si_commas` with `out +=` instead of `return std::string("-") + ...` to match file style.

## Testing
- Build Launcher and DigitViewer2.
- No behavior change; comments and exception text only where applicable.